### PR TITLE
Fix navbar and reload button spacing

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -48,7 +48,7 @@ class _HomePageState extends State<HomePage> {
               ),
               Positioned(
                 right: 16,
-                bottom: 16,
+                bottom: 100,
                 child: FloatingActionButton(
                   onPressed: _isLoading ? null : _handleRefresh,
                   tooltip: 'Refresh Cards',

--- a/lib/widgets/bubble_navbar.dart
+++ b/lib/widgets/bubble_navbar.dart
@@ -13,7 +13,7 @@ class BubbleNavbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.all(16),
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 32),
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
         color: Theme.of(context).cardColor,


### PR DESCRIPTION
## Summary
- adjust bubble navbar margin to float higher
- move the refresh FAB upward to avoid overlapping with the navbar

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602c7f31908333a026d963d6d59bbc