### PR TITLE
Float navbar above phone commands

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -48,7 +48,7 @@ class _HomePageState extends State<HomePage> {
               ),
               Positioned(
                 right: 16,
-                bottom: 80,
+                bottom: 100,
                 child: FloatingActionButton(
                   onPressed: _isLoading ? null : _handleRefresh,
                   tooltip: 'Refresh Cards',

--- a/lib/pages/main_layout.dart
+++ b/lib/pages/main_layout.dart
@@ -35,7 +35,7 @@ class _MainLayoutState extends State<MainLayout> {
           Positioned(
             left: 24,
             right: 24,
-            bottom: 0,
+            bottom: MediaQuery.of(context).padding.bottom + 20,
             child: BubbleNavbar(
               currentIndex: _currentIndex,
               onTap: (index) => setState(() => _currentIndex = index),


### PR DESCRIPTION
## Summary
- move the bubble navbar up off the screen edge
- adjust floating action button position to keep space

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686032eb327c8333acd5dca49598adff