### PR TITLE
Move draft pagination up and shrink images

### DIFF
--- a/lib/pages/draft_page.dart
+++ b/lib/pages/draft_page.dart
@@ -21,7 +21,7 @@ class _DraftPageState extends State<DraftPage> {
   final TextEditingController _searchController = TextEditingController();
 
   int _currentPage = 0;
-  final int _cardsPerPage = 30;
+  final int _cardsPerPage = 10;
 
   @override
   void initState() {
@@ -124,57 +124,63 @@ class _DraftPageState extends State<DraftPage> {
                 _loadingCards
                     ? const Expanded(child: Center(child: CircularProgressIndicator()))
                     : Expanded(
-                        child: ListView.builder(
-                          itemCount: _currentPageCards.length,
-                          itemBuilder: (context, index) {
-                            final card = _currentPageCards[index];
-                            return ListTile(
-                              dense: true,
-                              contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-                              leading: card.imageUrl.isNotEmpty
-                                  ? Image.network(
-                                      card.imageUrl,
-                                      width: 40,
-                                      height: 60,
-                                      fit: BoxFit.cover,
-                                      errorBuilder: (c, e, s) => const Icon(Icons.broken_image),
-                                    )
-                                  : null,
-                              title: Text(card.name, overflow: TextOverflow.ellipsis),
-                              onTap: () => Navigator.of(context).push(
-                                MaterialPageRoute(
-                                  builder: (_) => ResultsPage(query: card.name),
+                        child: Column(
+                          children: [
+                            if (_filteredCards.length > _cardsPerPage)
+                              Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    IconButton(
+                                      icon: const Icon(Icons.chevron_left),
+                                      onPressed: _currentPage > 0
+                                          ? () => setState(() => _currentPage--)
+                                          : null,
+                                    ),
+                                    Text(
+                                      "Pagina ${_currentPage + 1} di ${(_filteredCards.length / _cardsPerPage).ceil()}",
+                                      style: const TextStyle(fontWeight: FontWeight.bold),
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(Icons.chevron_right),
+                                      onPressed: (_currentPage + 1) * _cardsPerPage < _filteredCards.length
+                                          ? () => setState(() => _currentPage++)
+                                          : null,
+                                    ),
+                                  ],
                                 ),
                               ),
-                            );
-                          },
+                            Expanded(
+                              child: ListView.builder(
+                                itemCount: _currentPageCards.length,
+                                itemBuilder: (context, index) {
+                                  final card = _currentPageCards[index];
+                                  return ListTile(
+                                    dense: true,
+                                    contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                                    leading: card.imageUrl.isNotEmpty
+                                        ? Image.network(
+                                            card.imageUrl,
+                                            width: 36,
+                                            height: 54,
+                                            fit: BoxFit.cover,
+                                            errorBuilder: (c, e, s) => const Icon(Icons.broken_image),
+                                          )
+                                        : null,
+                                    title: Text(card.name, overflow: TextOverflow.ellipsis),
+                                    onTap: () => Navigator.of(context).push(
+                                      MaterialPageRoute(
+                                        builder: (_) => ResultsPage(query: card.name),
+                                      ),
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          ],
                         ),
                       ),
-                if (_filteredCards.length > _cardsPerPage)
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        IconButton(
-                          icon: const Icon(Icons.chevron_left),
-                          onPressed: _currentPage > 0
-                              ? () => setState(() => _currentPage--)
-                              : null,
-                        ),
-                        Text(
-                          "Pagina ${_currentPage + 1} di ${(_filteredCards.length / _cardsPerPage).ceil()}",
-                          style: const TextStyle(fontWeight: FontWeight.bold),
-                        ),
-                        IconButton(
-                          icon: const Icon(Icons.chevron_right),
-                          onPressed: (_currentPage + 1) * _cardsPerPage < _filteredCards.length
-                              ? () => setState(() => _currentPage++)
-                              : null,
-                        ),
-                      ],
-                    ),
-                  ),
               ],
             ),
           ),

--- a/lib/pages/results_page.dart
+++ b/lib/pages/results_page.dart
@@ -343,12 +343,12 @@ class _ResultsPageState extends State<ResultsPage> {
                                     padding: const EdgeInsets.only(right: 8.0),
                                     child: Image.network(
                                       card.propertiesHash['imageUrl'],
-                                      width: 60,
-                                      height: 90,
+                                      width: 50,
+                                      height: 75,
                                       fit: BoxFit.cover,
                                       errorBuilder: (context, error, stackTrace) => Container(
-                                        width: 60,
-                                        height: 90,
+                                        width: 50,
+                                        height: 75,
                                         color: Colors.grey[200],
                                         child: const Center(
                                           child: Icon(Icons.broken_image, size: 30, color: Colors.grey),


### PR DESCRIPTION
## Summary
- make card thumbnails a bit smaller
- show page controls at the top of DraftPage
- default to 10 cards per page in DraftPage

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603bee12a4833399a8e040d403577f