### PR TITLE
Aggiunge drawer e navbar più piccola

### DIFF
--- a/lib/pages/collection_page.dart
+++ b/lib/pages/collection_page.dart
@@ -1,9 +1,15 @@
 import 'package:flutter/material.dart';
 import '../services/local_storage.dart';
 import '../models/card_marketplace.dart';
+import '../widgets/app_drawer.dart';
 
 class CollectionPage extends StatefulWidget {
-  const CollectionPage({super.key});
+  final Function(int) onNavigate;
+
+  const CollectionPage({
+    super.key,
+    required this.onNavigate,
+  });
 
   @override
   State<CollectionPage> createState() => _CollectionPageState();
@@ -15,6 +21,7 @@ class _CollectionPageState extends State<CollectionPage> {
     final collection = LocalStorage().collection;
     return Scaffold(
       appBar: AppBar(title: const Text('La Tua Collezione')),
+      drawer: AppDrawer(currentIndex: 1, onSelect: widget.onNavigate),
       body: collection.isEmpty
           ? const Center(child: Text('Nessuna carta nella collezione'))
           : ListView.builder(

--- a/lib/pages/draft_page.dart
+++ b/lib/pages/draft_page.dart
@@ -3,9 +3,15 @@ import '../services/scryfall_api.dart';
 import '../models/scryfall_set.dart';
 import '../models/card_model.dart';
 import 'results_page.dart';
+import '../widgets/app_drawer.dart';
 
 class DraftPage extends StatefulWidget {
-  const DraftPage({super.key});
+  final Function(int) onNavigate;
+
+  const DraftPage({
+    super.key,
+    required this.onNavigate,
+  });
 
   @override
   State<DraftPage> createState() => _DraftPageState();
@@ -78,21 +84,18 @@ class _DraftPageState extends State<DraftPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        AppBar(
-          title: const Text('Modalità Draft'),
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-        ),
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              children: [
-                _loadingSets
-                    ? const CircularProgressIndicator()
-                    : DropdownButtonFormField<ScryfallSet>(
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Modalità Draft'),
+      ),
+      drawer: AppDrawer(currentIndex: 3, onSelect: widget.onNavigate),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            _loadingSets
+                ? const CircularProgressIndicator()
+                : DropdownButtonFormField<ScryfallSet>(
                         value: _selectedSet,
                         hint: const Text('Seleziona espansione'),
                         items: _sets
@@ -181,11 +184,13 @@ class _DraftPageState extends State<DraftPage> {
                           ],
                         ),
                       ),
+                    ],
+                  ),
+                ),
               ],
             ),
           ),
         ),
-      ],
-    );
+      );
   }
 }

--- a/lib/pages/main_layout.dart
+++ b/lib/pages/main_layout.dart
@@ -18,15 +18,19 @@ class _MainLayoutState extends State<MainLayout> {
   final GlobalKey<HomePageState> _homePageKey = GlobalKey<HomePageState>();
   late final List<Widget> _pages;
 
+  void _onPageSelected(int index) {
+    setState(() => _currentIndex = index);
+  }
+
   @override
   void initState() {
     super.initState();
     _pages = [
       HomePage(key: _homePageKey),
-      const CollectionPage(),
-      const WatchlistPage(),
-      const DraftPage(),
-      const ProfilePage(),
+      CollectionPage(onNavigate: _onPageSelected),
+      WatchlistPage(onNavigate: _onPageSelected),
+      DraftPage(onNavigate: _onPageSelected),
+      ProfilePage(onNavigate: _onPageSelected),
     ];
   }
 
@@ -38,15 +42,16 @@ class _MainLayoutState extends State<MainLayout> {
           SafeArea(
             child: _pages[_currentIndex],
           ),
-          Positioned(
-            left: 24,
-            right: 24,
-            bottom: MediaQuery.of(context).padding.bottom + 20,
-            child: BubbleNavbar(
-              currentIndex: _currentIndex,
-              onTap: (index) => setState(() => _currentIndex = index),
+          if (_currentIndex == 0)
+            Positioned(
+              left: 24,
+              right: 24,
+              bottom: MediaQuery.of(context).padding.bottom + 20,
+              child: BubbleNavbar(
+                currentIndex: _currentIndex,
+                onTap: _onPageSelected,
+              ),
             ),
-          ),
           if (_currentIndex == 0)
             Positioned(
               right: 16,

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -1,35 +1,36 @@
 import 'package:flutter/material.dart';
+import '../widgets/app_drawer.dart';
 
 class ProfilePage extends StatelessWidget {
-  const ProfilePage({super.key});
+  final Function(int) onNavigate;
+
+  const ProfilePage({
+    super.key,
+    required this.onNavigate,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        AppBar(
-          title: const Text('Profilo'),
-          backgroundColor: Colors.transparent,
-          elevation: 0,
-          actions: [
-            IconButton(
-              icon: const Icon(Icons.settings),
-              onPressed: () {},
-            ),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Profilo'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {},
+          ),
+        ],
+      ),
+      drawer: AppDrawer(currentIndex: 4, onSelect: onNavigate),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            _buildProfileHeader(),
+            _buildStatsSection(),
+            _buildProfileActions(),
           ],
         ),
-        Expanded(
-          child: SingleChildScrollView(
-            child: Column(
-              children: [
-                _buildProfileHeader(),
-                _buildStatsSection(),
-                _buildProfileActions(),
-              ],
-            ),
-          ),
-        ),
-      ],
+      ),
     );
   }
 

--- a/lib/pages/watchlist_page.dart
+++ b/lib/pages/watchlist_page.dart
@@ -1,9 +1,15 @@
 import 'package:flutter/material.dart';
 import '../services/local_storage.dart';
 import '../models/card_marketplace.dart';
+import '../widgets/app_drawer.dart';
 
 class WatchlistPage extends StatefulWidget {
-  const WatchlistPage({super.key});
+  final Function(int) onNavigate;
+
+  const WatchlistPage({
+    super.key,
+    required this.onNavigate,
+  });
 
   @override
   State<WatchlistPage> createState() => _WatchlistPageState();
@@ -15,6 +21,7 @@ class _WatchlistPageState extends State<WatchlistPage> {
     final watchlist = LocalStorage().watchlist;
     return Scaffold(
       appBar: AppBar(title: const Text('Watchlist')),
+      drawer: AppDrawer(currentIndex: 2, onSelect: widget.onNavigate),
       body: watchlist.isEmpty
           ? const Center(child: Text('Nessuna carta nella watchlist'))
           : ListView.builder(

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class AppDrawer extends StatelessWidget {
+  final int currentIndex;
+  final Function(int) onSelect;
+
+  const AppDrawer({
+    super.key,
+    required this.currentIndex,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: [
+          DrawerHeader(
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.primaryContainer,
+            ),
+            child: const Align(
+              alignment: Alignment.bottomLeft,
+              child: Text(
+                'CardWatch',
+                style: TextStyle(fontSize: 24, color: Colors.white),
+              ),
+            ),
+          ),
+          _buildItem(context, Icons.home, 'Home', 0),
+          _buildItem(context, Icons.collections, 'Collection', 1),
+          _buildItem(context, Icons.favorite, 'Watchlist', 2),
+          _buildItem(context, Icons.shuffle, 'Draft', 3),
+          _buildItem(context, Icons.person, 'Profilo', 4),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItem(
+      BuildContext context, IconData icon, String label, int index) {
+    final isSelected = currentIndex == index;
+    return ListTile(
+      leading: Icon(icon, color: isSelected ? Colors.blue : null),
+      title: Text(
+        label,
+        style: TextStyle(
+          color: isSelected ? Colors.blue : null,
+          fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+        ),
+      ),
+      onTap: () {
+        Navigator.pop(context);
+        onSelect(index);
+      },
+    );
+  }
+}

--- a/lib/widgets/bubble_navbar.dart
+++ b/lib/widgets/bubble_navbar.dart
@@ -13,7 +13,7 @@ class BubbleNavbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
         color: Theme.of(context).cardColor,
         borderRadius: BorderRadius.circular(30),
@@ -44,7 +44,7 @@ class BubbleNavbar extends StatelessWidget {
     return GestureDetector(
       onTap: () => onTap(index),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
         decoration: BoxDecoration(
           color: isSelected ? Colors.blue : Colors.transparent,
           borderRadius: BorderRadius.circular(25),


### PR DESCRIPTION
## Summary
- add a drawer widget with navigation items
- shrink bubble navbar padding
- use the drawer on collection, watchlist, draft and profile pages
- show bubble navbar only on the homepage

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861083487d0833388e0090a20b73106