### PR TITLE
Enable expansion search and larger menu icon

### DIFF
--- a/lib/pages/collection_page.dart
+++ b/lib/pages/collection_page.dart
@@ -20,7 +20,16 @@ class _CollectionPageState extends State<CollectionPage> {
   Widget build(BuildContext context) {
     final collection = LocalStorage().collection;
     return Scaffold(
-      appBar: AppBar(title: const Text('La Tua Collezione')),
+      appBar: AppBar(
+        leadingWidth: 64,
+        leading: Builder(
+          builder: (context) => IconButton(
+            icon: const Icon(Icons.menu, size: 32),
+            onPressed: () => Scaffold.of(context).openDrawer(),
+          ),
+        ),
+        title: const Text('La Tua Collezione'),
+      ),
       drawer: AppDrawer(currentIndex: 1, onSelect: widget.onNavigate),
       body: collection.isEmpty
           ? const Center(child: Text('Nessuna carta nella collezione'))

--- a/lib/pages/draft_page.dart
+++ b/lib/pages/draft_page.dart
@@ -86,6 +86,13 @@ class _DraftPageState extends State<DraftPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        leadingWidth: 64,
+        leading: Builder(
+          builder: (context) => IconButton(
+            icon: const Icon(Icons.menu, size: 32),
+            onPressed: () => Scaffold.of(context).openDrawer(),
+          ),
+        ),
         title: const Text('Modalità Draft'),
       ),
       drawer: AppDrawer(currentIndex: 3, onSelect: widget.onNavigate),
@@ -95,18 +102,37 @@ class _DraftPageState extends State<DraftPage> {
           children: [
             _loadingSets
                 ? const CircularProgressIndicator()
-                : DropdownButtonFormField<ScryfallSet>(
-                    value: _selectedSet,
-                    hint: const Text('Seleziona espansione'),
-                    items: _sets
-                        .map((s) => DropdownMenuItem(
-                              value: s,
-                              child: Text(s.name),
-                            ))
-                        .toList(),
-                    onChanged: (value) {
-                      setState(() => _selectedSet = value);
-                      if (value != null) _loadCardsForSet(value.code);
+                : Autocomplete<ScryfallSet>(
+                    initialValue: _selectedSet != null
+                        ? TextEditingValue(text: _selectedSet!.name)
+                        : const TextEditingValue(),
+                    optionsBuilder: (TextEditingValue value) {
+                      if (value.text.isEmpty) {
+                        return const Iterable<ScryfallSet>.empty();
+                      }
+                      return _sets.where((s) =>
+                          s.name.toLowerCase().contains(value.text.toLowerCase()));
+                    },
+                    displayStringForOption: (s) => s.name,
+                    fieldViewBuilder:
+                        (context, textController, focusNode, onFieldSubmitted) {
+                      return TextField(
+                        controller: textController,
+                        focusNode: focusNode,
+                        decoration: InputDecoration(
+                          labelText: 'Cerca espansione',
+                          prefixIcon: const Icon(Icons.search),
+                          isDense: true,
+                          contentPadding: const EdgeInsets.symmetric(
+                              vertical: 8, horizontal: 12),
+                          border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(30)),
+                        ),
+                      );
+                    },
+                    onSelected: (s) {
+                      setState(() => _selectedSet = s);
+                      _loadCardsForSet(s.code);
                     },
                   ),
             const SizedBox(height: 16),

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -13,6 +13,13 @@ class ProfilePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        leadingWidth: 64,
+        leading: Builder(
+          builder: (context) => IconButton(
+            icon: const Icon(Icons.menu, size: 32),
+            onPressed: () => Scaffold.of(context).openDrawer(),
+          ),
+        ),
         title: const Text('Profilo'),
         actions: [
           IconButton(

--- a/lib/pages/watchlist_page.dart
+++ b/lib/pages/watchlist_page.dart
@@ -20,7 +20,16 @@ class _WatchlistPageState extends State<WatchlistPage> {
   Widget build(BuildContext context) {
     final watchlist = LocalStorage().watchlist;
     return Scaffold(
-      appBar: AppBar(title: const Text('Watchlist')),
+      appBar: AppBar(
+        leadingWidth: 64,
+        leading: Builder(
+          builder: (context) => IconButton(
+            icon: const Icon(Icons.menu, size: 32),
+            onPressed: () => Scaffold.of(context).openDrawer(),
+          ),
+        ),
+        title: const Text('Watchlist'),
+      ),
       drawer: AppDrawer(currentIndex: 2, onSelect: widget.onNavigate),
       body: watchlist.isEmpty
           ? const Center(child: Text('Nessuna carta nella watchlist'))


### PR DESCRIPTION
## Summary
- use `Autocomplete` to search expansions in draft mode
- enlarge the drawer hamburger button on all pages

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686167592b7483339e854b1c24eeddbb