### PR TITLE
Migliora resilienza caricamento carte (retry Scryfall + guard Marketplace)

### DIFF
--- a/lib/services/marketplace_service.dart
+++ b/lib/services/marketplace_service.dart
@@ -10,6 +10,7 @@ import '../models/enums/card_game_id.dart';
 class MarketplaceService {
   static String get _baseUrl => dotenv.env['BASE_MARKETPLACE_API'] ?? '';
   static String get _token => dotenv.env['MARKETPLACE_TOKEN'] ?? '';
+  static bool get _isConfigured => _baseUrl.isNotEmpty && _token.isNotEmpty;
 
   static Map<String, String> get _headers => {
     'Authorization': 'Bearer $_token',
@@ -18,9 +19,11 @@ class MarketplaceService {
 
   // Equivalente di getBlueprintList
   static Future<List<CardBlueprint>> getBlueprintList(String query) async {
+    if (!_isConfigured) return [];
+
     try {
-      
-      final url = '$_baseUrl/blueprints?game_id=${CardGameId.MAGIC.value}&name=$query';
+      final encodedQuery = Uri.encodeQueryComponent(query);
+      final url = '$_baseUrl/blueprints?game_id=${CardGameId.MAGIC.value}&name=$encodedQuery';
       final response = await http.get(
         Uri.parse(url),
         headers: _headers,
@@ -39,6 +42,8 @@ class MarketplaceService {
 
   // Equivalente di getMarketCard
   static Future<List<CardMarketplace>> getMarketCard(int blueprintId) async {
+    if (!_isConfigured) return [];
+
     try {
       final url = '$_baseUrl/marketplace/products?blueprint_id=$blueprintId';
       final response = await http.get(

--- a/lib/services/unified_card_service.dart
+++ b/lib/services/unified_card_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/card_model.dart';
@@ -47,14 +48,24 @@ class UnifiedCardService {
   /// Ottiene una carta random da Scryfall
   static Future<CardModel> _getRandomScryfallCard() async {
     final url = Uri.parse('https://api.scryfall.com/cards/random');
-    final res = await http.get(url);
 
-    if (res.statusCode == 200) {
-      final cardJson = json.decode(res.body);
-      return CardModel.fromScryfallJson(cardJson);
-    } else {
+    for (int attempt = 0; attempt < 3; attempt++) {
+      final res = await http.get(url).timeout(const Duration(seconds: 10));
+
+      if (res.statusCode == 200) {
+        final cardJson = json.decode(res.body);
+        return CardModel.fromScryfallJson(cardJson);
+      }
+
+      if (res.statusCode == 429 || res.statusCode >= 500) {
+        await Future.delayed(Duration(milliseconds: 300 * (attempt + 1)));
+        continue;
+      }
+
       throw Exception('Errore nel fetch della carta random: ${res.statusCode}');
     }
+
+    throw Exception('Errore nel fetch della carta random: troppi tentativi falliti');
   }
 
   /// Arricchisce una carta con dati dal marketplace


### PR DESCRIPTION
### Motivation
- Le chiamate al marketplace potevano far fallire o degradare il caricamento delle carte quando le variabili di ambiente non erano configurate o il nome della carta conteneva spazi/caratteri speciali.
- Le chiamate a Scryfall per carte casuali erano sensibili a timeout ed errori transitori (429/5xx) causando risultati vuoti visibili all'utente.

### Description
- Aggiunta della proprietà `static bool get _isConfigured` in `lib/services/marketplace_service.dart` e salto immediato delle chiamate marketplace quando `BASE_MARKETPLACE_API` o `MARKETPLACE_TOKEN` non sono presenti usando `if (!_isConfigured) return [];`.
- URL-encoding del parametro `name` nelle richieste blueprint con `Uri.encodeQueryComponent(query)` per evitare URL malformate per nomi con spazi/caratteri speciali in `lib/services/marketplace_service.dart`.
- Migliorata robustezza di `_getRandomScryfallCard` in `lib/services/unified_card_service.dart` aggiungendo l`import` di `dart:async`, `timeout` sulle richieste, fino a 3 tentativi con breve backoff su risposte `429` o `5xx`, e messaggio di errore finale se esauriti i tentativi.

### Testing
- Tentativo di eseguire `flutter test` in questo ambiente automatizzato: fallito perché il comando `flutter` non è presente (`flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb552862e08333a4221ef9a06d078d)